### PR TITLE
Feature: `Area` and `Line` objects & collision algorithm

### DIFF
--- a/Haskell/Models/Area.hs
+++ b/Haskell/Models/Area.hs
@@ -1,6 +1,7 @@
 module Models.Area where
 
 import Models.Line (Line (Line))
+import qualified Models.Line as Line
 import Utils.Lists (mapWithIndex)
 import Utils.Strings (removeLeadingSpaces)
 
@@ -29,3 +30,11 @@ parseLine baseX baseY stringLine = Line originX originY endX
     numberOfLeadingSpaces = length stringLine - numberOfValidCharacters
     numberOfValidCharacters = length stringLineWithoutLeadingSpaces
     stringLineWithoutLeadingSpaces = removeLeadingSpaces stringLine
+
+overlapsWith :: Area -> Area -> Bool
+overlapsWith area anotherArea =
+  anyLinesOverlap (occupiedLines area) (occupiedLines anotherArea)
+
+anyLinesOverlap :: [Line] -> [Line] -> Bool
+anyLinesOverlap lines otherLines =
+  any (\line -> any (Line.overlapsWith line) otherLines) lines

--- a/Haskell/Models/Area.hs
+++ b/Haskell/Models/Area.hs
@@ -1,0 +1,31 @@
+module Models.Area where
+
+import Models.Line (Line (Line))
+import Utils.Lists (mapWithIndex)
+import Utils.Strings (removeLeadingSpaces)
+
+newtype Area = Area
+  {occupiedLines :: [Line]}
+  deriving (Show)
+
+createFromString :: Int -> Int -> String -> Area
+createFromString originX originY string =
+  Area (parseLines originX originY string)
+
+parseLines :: Int -> Int -> String -> [Line]
+parseLines originX originY string =
+  mapWithIndex
+    (\stringLine index -> parseLine originX (originY + index) stringLine)
+    stringLines
+  where
+    stringLines = lines string
+
+parseLine :: Int -> Int -> String -> Line
+parseLine baseX baseY stringLine = Line originX originY endX
+  where
+    originX = baseX + numberOfLeadingSpaces
+    originY = baseY
+    endX = originX + numberOfValidCharacters - 1
+    numberOfLeadingSpaces = length stringLine - numberOfValidCharacters
+    numberOfValidCharacters = length stringLineWithoutLeadingSpaces
+    stringLineWithoutLeadingSpaces = removeLeadingSpaces stringLine

--- a/Haskell/Models/Line.hs
+++ b/Haskell/Models/Line.hs
@@ -1,0 +1,8 @@
+module Models.Line where
+
+data Line = Line
+  { originX :: Int,
+    originY :: Int,
+    endX :: Int
+  }
+  deriving (Show)

--- a/Haskell/Models/Line.hs
+++ b/Haskell/Models/Line.hs
@@ -6,3 +6,11 @@ data Line = Line
     endX :: Int
   }
   deriving (Show)
+
+overlapsWith :: Line -> Line -> Bool
+overlapsWith line anotherLine
+  | not haveSameOriginY = False
+  | originX line <= originX anotherLine = endX line >= originX anotherLine
+  | otherwise = endX anotherLine >= originX line
+  where
+    haveSameOriginY = originY line == originY anotherLine

--- a/Haskell/Utils/Lists.hs
+++ b/Haskell/Utils/Lists.hs
@@ -1,0 +1,15 @@
+module Utils.Lists where
+
+import qualified Data.Foldable as Foldable
+import qualified Data.Sequence as Sequence
+
+mapWithIndex :: (a -> Int -> b) -> [a] -> [b]
+mapWithIndex function list =
+  convertSequenceToList
+    (Sequence.mapWithIndex (flip function) (convertListToSequence list))
+
+convertListToSequence :: [a] -> Sequence.Seq a
+convertListToSequence = Sequence.fromList
+
+convertSequenceToList :: Sequence.Seq a -> [a]
+convertSequenceToList = Foldable.toList

--- a/Haskell/Utils/Strings.hs
+++ b/Haskell/Utils/Strings.hs
@@ -1,0 +1,6 @@
+module Utils.Strings where
+
+removeLeadingSpaces :: String -> String
+removeLeadingSpaces string
+  | null string || head string /= ' ' = string
+  | otherwise = removeLeadingSpaces (tail string)


### PR DESCRIPTION
### Features
- Created the objects `Area` and `Line`.
- Implemented the collision algorithm.

Examples:
```haskell
import qualified Models.Area as Area
import qualified Models.Line as Line

main :: IO ()
main = do
  let area1 = Area.createFromString 0 0 "  ###\n #####\n  ###"
  let area2 = Area.createFromString 0 0 "--\n-\n--"
  let area3 = Area.createFromString 0 2 "    ---\n---"

  print (Area.overlapsWith area1 area2) -- False
  print (Area.overlapsWith area3 area1) -- True
```

Closes #18 e #19.