### PR TITLE
Feature: Pipe and PipeGroup

### DIFF
--- a/Haskell/Models/Area.hs
+++ b/Haskell/Models/Area.hs
@@ -9,9 +9,16 @@ newtype Area = Area
   {occupiedLines :: [Line]}
   deriving (Show)
 
+createFromLines :: [Line] -> Area
+createFromLines = Area
+
 createFromString :: Int -> Int -> String -> Area
 createFromString originX originY string =
-  Area (parseLines originX originY string)
+  createFromLines (parseLines originX originY string)
+
+merge :: Area -> Area -> Area
+merge area anotherArea =
+  createFromLines (occupiedLines area ++ occupiedLines anotherArea)
 
 parseLines :: Int -> Int -> String -> [Line]
 parseLines originX originY string =

--- a/Haskell/Models/Pipe.hs
+++ b/Haskell/Models/Pipe.hs
@@ -23,6 +23,13 @@ data Pipe = Pipe
   }
   deriving (Show)
 
+tick :: Pipe -> Pipe
+tick pipe = setOriginX pipe (originX pipe - 1)
+
+setOriginX :: Pipe -> Int -> Pipe
+setOriginX pipe newOriginX =
+  Pipe newOriginX (originY pipe) (width pipe) (height pipe) (direction pipe)
+
 getArea :: Pipe -> Area
 getArea pipe =
   Area.createFromString (originX pipe) (originY pipe) (toString pipe)

--- a/Haskell/Models/Pipe.hs
+++ b/Haskell/Models/Pipe.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds #-}
+
+module Models.Pipe where
+
+import Data.List (intercalate)
+import Models.Area
+import qualified Models.Area as Area
+
+pipeCharacter = '#'
+
+type UP = "UP"
+
+type DOWN = "DOWN"
+
+data Direction = UP | DOWN deriving (Show, Eq)
+
+data Pipe = Pipe
+  { originX :: Int,
+    originY :: Int,
+    width :: Int,
+    height :: Int,
+    direction :: Direction
+  }
+  deriving (Show)
+
+getArea :: Pipe -> Area
+getArea pipe =
+  Area.createFromString (originX pipe) (originY pipe) (toString pipe)
+
+toString :: Pipe -> String
+toString pipe
+  | direction pipe == DOWN = toDownString pipe
+  | otherwise = toUpString pipe
+
+toDownString :: Pipe -> String
+toDownString pipe = reverse (toUpString pipe)
+
+toUpString :: Pipe -> String
+toUpString pipe =
+  intercalate "\n" (toStringLines pipe)
+
+toStringLines :: Pipe -> [String]
+toStringLines pipe = replicate (height pipe) line
+  where
+    line = replicate (width pipe) pipeCharacter

--- a/Haskell/Models/PipeGroup.hs
+++ b/Haskell/Models/PipeGroup.hs
@@ -24,6 +24,13 @@ create originX originY width height holeOriginY holeHeight =
     bottomPipeOriginY = originY + topPipeHeight + holeHeight
     bottomPipeHeight = height - topPipeHeight - holeHeight
 
+tick :: PipeGroup -> PipeGroup
+tick pipeGroup =
+  PipeGroup newTopPipe newBottomPipe (width pipeGroup) (holeHeight pipeGroup)
+  where
+    newTopPipe = Pipe.tick (topPipe pipeGroup)
+    newBottomPipe = Pipe.tick (bottomPipe pipeGroup)
+
 getArea :: PipeGroup -> Area
 getArea pipeGroup = Area.merge topPipeArea bottomPipeArea
   where

--- a/Haskell/Models/PipeGroup.hs
+++ b/Haskell/Models/PipeGroup.hs
@@ -1,0 +1,40 @@
+module Models.PipeGroup where
+
+import Data.List (intercalate)
+import Models.Area (Area)
+import qualified Models.Area as Area
+import Models.Pipe (Pipe (Pipe))
+import qualified Models.Pipe as Pipe
+
+data PipeGroup = PipeGroup
+  { topPipe :: Pipe,
+    bottomPipe :: Pipe,
+    width :: Int,
+    holeHeight :: Int
+  }
+  deriving (Show)
+
+create :: Int -> Int -> Int -> Int -> Int -> Int -> PipeGroup
+create originX originY width height holeOriginY holeHeight =
+  PipeGroup topPipe bottomPipe width holeHeight
+  where
+    topPipe = Pipe originX originY width topPipeHeight Pipe.DOWN
+    topPipeHeight = holeOriginY - originY
+    bottomPipe = Pipe originX bottomPipeOriginY width bottomPipeHeight Pipe.UP
+    bottomPipeOriginY = originY + topPipeHeight + holeHeight
+    bottomPipeHeight = height - topPipeHeight - holeHeight
+
+getArea :: PipeGroup -> Area
+getArea pipeGroup = Area.merge topPipeArea bottomPipeArea
+  where
+    topPipeArea = Pipe.getArea (topPipe pipeGroup)
+    bottomPipeArea = Pipe.getArea (bottomPipe pipeGroup)
+
+toString :: PipeGroup -> String
+toString pipeGroup =
+  intercalate "\n" [topPipeAsString, hole, bottomPipeAsString]
+  where
+    topPipeAsString = Pipe.toString (topPipe pipeGroup)
+    bottomPipeAsString = Pipe.toString (bottomPipe pipeGroup)
+    hole = intercalate "\n" (replicate (holeHeight pipeGroup) holeLine)
+    holeLine = replicate (width pipeGroup) ' '


### PR DESCRIPTION
### Features
- Implemented the type classes `Pipe` and `PipeGroup`, including their `getArea()`, `toString()` and `tick()` methods.

Examples:
```haskell
import qualified Models.Area as Area
import qualified Models.Line as Line
import Models.Pipe (Pipe (Pipe))
import qualified Models.Pipe as Pipe
import Models.PipeGroup (PipeGroup (PipeGroup))
import qualified Models.PipeGroup as PipeGroup
import Text.Printf (printf)

main :: IO ()
main = do
  let pipe = Pipe 0 0 4 5 Pipe.UP
  printf "%s\n" (Pipe.toString pipe)
  print (Pipe.getArea pipe)

  -- <originX> <originY> <width> <height> <holeOriginY> <holeHeight>
  let pipeGroup = PipeGroup.create 2 0 4 6 2 1

  printf "%s\n" (PipeGroup.toString pipeGroup)
  print (Pipe.getArea (PipeGroup.topPipe pipeGroup))
  print (Pipe.getArea (PipeGroup.bottomPipe pipeGroup))
  print (PipeGroup.getArea pipeGroup)

  let tickedPipeGroup = PipeGroup.tick pipeGroup -- move pipe group coordinates one unit to the left

  printf "%s\n" (PipeGroup.toString tickedPipeGroup)
  print (Pipe.getArea (PipeGroup.topPipe tickedPipeGroup))
  print (Pipe.getArea (PipeGroup.bottomPipe tickedPipeGroup))
  print (PipeGroup.getArea tickedPipeGroup)
```

Closes #13.