### PR TITLE
feat: area, line and collision algorithm

### DIFF
--- a/Prolog/.editorconfig
+++ b/Prolog/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Prolog/models/area.pl
+++ b/Prolog/models/area.pl
@@ -1,3 +1,35 @@
-:- module(area,[testMethodArea/1]).
+:- module(area, [createFromLines/2, createFromString/4]).
 
-testMethodArea(Param):- write(Param).
+:- use_module('../utils/strings').
+:- use_module(line).
+
+createFromLines(OccupiedLines, Area):-
+  Area = area(lines(OccupiedLines)).
+
+createFromString(OriginX, OriginY, String, Area):-
+  strings:lines(String, StringLines),
+  parseStringLines(OriginX, OriginY, StringLines, OccupiedLines),
+  createFromLines(OccupiedLines, Area).
+
+parseStringLines(OriginX, OriginY, StringLines, Lines):-
+  parseStringLinesRecursive(OriginX, OriginY, StringLines, 0, Lines).
+
+parseStringLinesRecursive(_OriginX, _OriginY, [], _Index, []).
+parseStringLinesRecursive(OriginX, OriginY, [StringLine | TailStringLines], Index, [Line | TailLines]):-
+  NextIndex is Index + 1,
+  parseStringLinesRecursive(OriginX, OriginY, TailStringLines, NextIndex, TailLines),
+  LineOriginY is OriginY + Index,
+  parseStringLine(OriginX, LineOriginY, StringLine, Line).
+
+parseStringLine(BaseX, BaseY, StringLine, Line):-
+  strings:size(StringLine, StringLineLength),
+  strings:removeLeadingSpaces(StringLine, StringLineWithoutLeadingSpaces),
+  strings:size(StringLineWithoutLeadingSpaces, NumberOfValidCharacters),
+  NumberOfLeadingSpaces is StringLineLength - NumberOfValidCharacters,
+  OriginX is BaseX + NumberOfLeadingSpaces,
+  OriginY = BaseY,
+  EndX is OriginX + NumberOfValidCharacters - 1,
+  line:create(OriginX, OriginY, EndX, Line).
+
+occupiedLines(Area, OccupiedLines):-
+  Area = area(lines(OccupiedLines)).

--- a/Prolog/models/area.pl
+++ b/Prolog/models/area.pl
@@ -31,5 +31,10 @@ parseStringLine(BaseX, BaseY, StringLine, Line):-
   EndX is OriginX + NumberOfValidCharacters - 1,
   line:create(OriginX, OriginY, EndX, Line).
 
+overlapsWith(Area, AnotherArea, Overlaps):-
+  occupiedLines(Area, AreaLines),
+  occupiedLines(AnotherArea, AnotherAreaLines),
+  (line:anyLinesOverlap(AreaLines, AnotherAreaLines) -> Overlaps = true; Overlaps = false).
+
 occupiedLines(Area, OccupiedLines):-
   Area = area(lines(OccupiedLines)).

--- a/Prolog/models/line.pl
+++ b/Prolog/models/line.pl
@@ -1,3 +1,13 @@
-:- module(line,[testMethodLine/1]).
+:- module(line, [create/4]).
 
-testMethodLine(Param):- write(Param).
+create(OriginX, OriginY, EndX, Line):-
+  Line = line(originX(OriginX), originY(OriginY), endX(EndX)).
+
+originX(Line, OriginX):-
+  Line = line(originX(OriginX), originY(_), endX(_)).
+
+originY(Line, OriginY):-
+  Line = line(originX(_), originY(OriginY), endX(_)).
+
+endX(Line, EndX):-
+  Line = line(originX(_), originY(_), endX(EndX)).

--- a/Prolog/models/line.pl
+++ b/Prolog/models/line.pl
@@ -11,3 +11,27 @@ originY(Line, OriginY):-
 
 endX(Line, EndX):-
   Line = line(originX(_), originY(_), endX(EndX)).
+
+overlapsWith(Line, AnotherLine):-
+  originX(Line, LineOriginX),
+  originY(Line, LineOriginY),
+  endX(Line, LineEndX),
+  originX(AnotherLine, AnotherLineOriginX),
+  originY(AnotherLine, AnotherLineOriginY),
+  endX(AnotherLine, AnotherLineEndX),
+  LineOriginY = AnotherLineOriginY,
+  (
+    LineOriginX =< AnotherLineOriginX ->
+      LineEndX >= AnotherLineOriginX;
+      AnotherLineEndX >= LineOriginX
+  ).
+
+overlapsWithAny(_Line, []):- false.
+overlapsWithAny(Line, [AnotherLine | TailLines]):-
+  overlapsWith(Line, AnotherLine);
+  overlapsWithAny(Line, TailLines).
+
+anyLinesOverlap([], _AnotherLines):- false.
+anyLinesOverlap([Line | TailLines], AnotherLines):-
+  overlapsWithAny(Line, AnotherLines);
+  anyLinesOverlap(TailLines, AnotherLines).

--- a/Prolog/utils/lists.pl
+++ b/Prolog/utils/lists.pl
@@ -1,3 +1,4 @@
-:- module(lists,[testMethodLists/1]).
+:- module(lists, [join/3]).
 
-testMethodLists(Param):- write(Param).
+join(List, Separator, JoinedList):-
+  atomic_list_concat(List, Separator, JoinedList).

--- a/Prolog/utils/strings.pl
+++ b/Prolog/utils/strings.pl
@@ -1,3 +1,39 @@
-:- module(strings,[testMethodStrings/1]).
+:- module(strings, [lines/2, size/2, removeLeadingSpaces/2]).
 
-testMethodStrings(Param):- write(Param).
+:- use_module(lists).
+
+split(String, Separator, StringParts):-
+  split_string(String, Separator, '', StringParts).
+
+lines(String, StringLines):-
+  split(String, '\n', StringLines).
+
+characters(String, StringCharacters):-
+  atom_chars(String, StringCharacters).
+
+size(String, StringSize):-
+  characters(String, StringCharacters),
+  length(StringCharacters, StringSize).
+
+removeLeadingSpaces(String, StringWithoutLeadingSpaces):-
+  characters(String, Characters),
+  removeLeadingSpacesFromCharacterList(
+    Characters,
+    CharactersExcludingLeadingSpaces
+  ),
+  lists:join(CharactersExcludingLeadingSpaces, '', StringWithoutLeadingSpaces).
+
+removeLeadingSpacesFromCharacterList([], []).
+removeLeadingSpacesFromCharacterList(
+  [Character | TailCharacters],
+  CharactersExcludingLeadingSpaces
+):-
+  (
+    Character = ' ' ->
+      removeLeadingSpacesFromCharacterList(
+        TailCharacters,
+        CharactersExcludingLeadingSpaces
+      );
+    CharactersExcludingLeadingSpaces = [Character | TailCharacters]
+  ).
+


### PR DESCRIPTION
### Feaures
- Implemented the entities `area` and `line`.
- Implemented the collision algorithm.
- Added an `.editorconfig` file to the project.

---

**Example**: creating areas
```prolog
:- use_module('models/area').
:- use_module('models/line').

main:-
  lines:create(0, 0, 5, Line),
  area:createFromLines([Line], Area1),
  writeln(Area1), % area(lines([line(originX(0),originY(0),endX(5))]))

  area:createFromString(0, 0, "...\n   ....\n..", Area2),
  writeln(Area2). % area(lines([line(originX(0),originY(0),endX(2)),line(originX(3),originY(1),endX(6)),line(originX(0),originY(2),endX(1))]))
```

**Example**: checking collision between areas
```prolog
:- use_module('models/area').
:- use_module('models/line').

main:-
  area:createFromString(0, 0, '  ###\n #####\n  ###', Area1),
  area:createFromString(0, 0, '--\n-\n--', Area2),
  area:createFromString(0, 2, '    ---\n---', Area3),

  area:overlapsWith(Area1, Area2, Area1And2Overlap),
  writeln(Area1And2Overlap), % false

  area:overlapsWith(Area3, Area1, Area3And1Overlap),
  writeln(Area3And1Overlap). % true
```